### PR TITLE
improve: remove dead local s in fibonacciString

### DIFF
--- a/fibonacci/v1/fibonacci.go
+++ b/fibonacci/v1/fibonacci.go
@@ -21,12 +21,10 @@ func fibonacci(n int) int64 {
 }
 
 func fibonacciString(n int) string {
-	s := ""
 	sb := new(strings.Builder)
 	for i := range n {
 		v := fibonacci(i)
 		sb.WriteString(strconv.FormatInt(v, 10) + "\n")
 	}
-	s += sb.String()
-	return s
+	return sb.String()
 }

--- a/fibonacci/v2/fibonacci.go
+++ b/fibonacci/v2/fibonacci.go
@@ -22,13 +22,11 @@ func fibonacci(n int) *big.Int {
 }
 
 func fibonacciString(n int) string {
-	s := ""
 	sb := new(strings.Builder)
 	for i := range n {
 		v := fibonacci(i)
 		vs := v.String()
 		sb.WriteString(vs + "\n")
 	}
-	s += sb.String()
-	return s
+	return sb.String()
 }

--- a/fibonacci/v3/fibonacci.go
+++ b/fibonacci/v3/fibonacci.go
@@ -25,7 +25,6 @@ func fibonacci(n int) *big.Int {
 }
 
 func fibonacciString(n int) string {
-	s := ""
 	sb := new(strings.Builder)
 	for i, v := range fibonacciSeq() {
 		if i >= n {
@@ -34,8 +33,7 @@ func fibonacciString(n int) string {
 		vs := v.String()
 		sb.WriteString(vs + "\n")
 	}
-	s += sb.String()
-	return s
+	return sb.String()
 }
 
 func fibonacciSeq() iter.Seq2[int, *big.Int] {


### PR DESCRIPTION
Remove the dead local variable `s` in `fibonacciString` (v1, v2, v3) that just copies the builder's output.

The pattern `s := ""; s += sb.String(); return s` is equivalent to `return sb.String()` since `s` is only assigned once (appending to an empty string).

Changes:
- `fibonacci/v1/fibonacci.go`: remove dead local `s`, return `sb.String()` directly
- `fibonacci/v2/fibonacci.go`: same
- `fibonacci/v3/fibonacci.go`: same