### PR TITLE
refactor(func-mock): drop redundant else in call function

### DIFF
--- a/func-mock/func_mock.go
+++ b/func-mock/func_mock.go
@@ -91,7 +91,6 @@ func checkType[F Func]() reflect.Type {
 func call(v reflect.Value, args []reflect.Value) []reflect.Value {
 	if v.Type().IsVariadic() {
 		return v.CallSlice(args)
-	} else {
-		return v.Call(args)
 	}
+	return v.Call(args)
 }


### PR DESCRIPTION
The `call` function used an `else` branch after a `return`, which is redundant.

```go
// Before
func call(v reflect.Value, args []reflect.Value) []reflect.Value {
	if v.Type().IsVariadic() {
		return v.CallSlice(args)
	} else {
		return v.Call(args)
	}
}

// After
func call(v reflect.Value, args []reflect.Value) []reflect.Value {
	if v.Type().IsVariadic() {
		return v.CallSlice(args)
	}
	return v.Call(args)
}
```

Behavior is unchanged. The `call` function remains at 100% test coverage (variadic branch covered by `TestVariadic`, non-variadic branch covered by other tests).